### PR TITLE
`URLClicker` のクローズ処理を修正

### DIFF
--- a/src/url-clicker.ts
+++ b/src/url-clicker.ts
@@ -20,7 +20,6 @@ export class URLClicker {
       try {
         await page.setDefaultNavigationTimeout(0);
         await page.goto(url);
-        await page.close();
         console.log(`Finish access to ${url}`);
       } catch (e) {
         console.log(e);


### PR DESCRIPTION
`URLClicker` のクローズ処理を修正.
`page.close()` が二重にあったため, try 側の close() 処理を削除.